### PR TITLE
Add custom callback for model metadata

### DIFF
--- a/mila/train/callback.py
+++ b/mila/train/callback.py
@@ -1,0 +1,26 @@
+"""Custom callbacks."""
+import json
+import logging
+import os
+
+from keras.callbacks import Callback
+
+
+class ModelMetadata(Callback):
+    def __init__(self, filename, categories):
+        super().__init__()
+        
+        self.filename = filename
+        self.categories = categories
+        self.logger = logging.getLogger(__name__)
+
+    def on_epoch_end(self, epoch, logs=None):
+        # Save some extra model metadata so we will know later what a prediction
+        # means.
+        logs = logs or {}
+        with open(self.filename, 'w') as f:
+            json.dump({
+                'classes': self.categories,
+                'latest_logs': dict(**logs)
+            }, f)
+

--- a/tests/serve/app_test.py
+++ b/tests/serve/app_test.py
@@ -66,19 +66,19 @@ def test_model_get_success(modeldata, configmock):
         'Accept': 'application/json'
     })
     assert res.status == 200
-    assert res.json == {
-        'network': {
-            'batch_size': None,
-            'image': {
-                'rows': 30,
-                'cols': 30,
-                'color_channels': 3
-            }
-        },
-        'meta': {
-            'classes': ['a', 'b']
+    assert res.json.get('network', {}) == {
+        'batch_size': None,
+        'image': {
+            'rows': 30,
+            'cols': 30,
+            'color_channels': 3
         }
     }
+    assert res.json.get('meta', {}).get('classes') == ['a', 'b']
+    assert res.json.get('meta', {}).get('latest_logs', {}).get('acc') >= 0
+    assert res.json.get('meta', {}).get('latest_logs', {}).get('loss') >= 0
+    assert res.json.get('meta', {}).get('latest_logs', {}).get('val_acc') >= 0
+    assert res.json.get('meta', {}).get('latest_logs', {}).get('val_loss') >= 0
 
 
 def test_model_get_prediction(modeldata, configmock):


### PR DESCRIPTION
This commit adds a Keras callback for writing the model metadata after
each completed epoch. The training callbacks for the simple network are
also updated to stop early and write model checkpoints only when
validation loss improves.